### PR TITLE
Allow sorting of computed attributes on sets that include nil values.

### DIFF
--- a/lib/active_set/sorting/enumerable_strategy.rb
+++ b/lib/active_set/sorting/enumerable_strategy.rb
@@ -14,7 +14,12 @@ class ActiveSet
         # http://brandon.dimcheff.com/2009/11/18/rubys-sort-vs-sort-by/
         @set.sort_by do |item|
           @attribute_instructions.map do |instruction|
-            sortable_numeric_for(instruction, item) * direction_multiplier(instruction.value)
+            value_for_comparison = sortable_numeric_for(instruction, item)
+            if value_for_comparison.nil?
+              [direction_multiplier(instruction.value), 0]
+            else
+              [0, value_for_comparison * direction_multiplier(instruction.value)]
+            end
           end
         end
       end

--- a/lib/active_set/sorting/enumerable_strategy.rb
+++ b/lib/active_set/sorting/enumerable_strategy.rb
@@ -15,10 +15,17 @@ class ActiveSet
         @set.sort_by do |item|
           @attribute_instructions.map do |instruction|
             value_for_comparison = sortable_numeric_for(instruction, item)
+            direction_multiplier = direction_multiplier(instruction.value)
+
+            # in an ASC sort, nils float to the end of the list. In a DESC
+            # sort, nils float to the start of the list. This is achieved by
+            # wrapping each value_for_comparison in a tuple with 0 as the first
+            # element, and wrapping nil values with either 1 or -1 as the first
+            # element
             if value_for_comparison.nil?
-              [direction_multiplier(instruction.value), 0]
+              [direction_multiplier, 0]
             else
-              [0, value_for_comparison * direction_multiplier(instruction.value)]
+              [0, value_for_comparison * direction_multiplier]
             end
           end
         end

--- a/spec/active_set/sort_spec.rb
+++ b/spec/active_set/sort_spec.rb
@@ -228,4 +228,40 @@ RSpec.describe ActiveSet do
       end
     end
   end
+
+  describe '#sort on a computed field with nil values in the set' do
+    before(:each) do
+      @a = OpenStruct.new(bar: 7)
+      @b = OpenStruct.new(bar: nil)
+      @c = OpenStruct.new(bar: 8)
+
+      @active_set = ActiveSet.new([@a, @b, @c])
+    end
+
+    let(:result) { @active_set.sort(instructions) }
+
+    context 'sorting ascending' do
+      let(:instructions) do
+        { 'bar': :asc }
+      end
+
+      it do
+        expect(result.first).to eq @a
+        expect(result.second).to eq @c
+        expect(result.last).to eq @b
+      end
+    end
+
+    context 'sorting desending' do
+      let(:instructions) do
+        { 'bar': :desc }
+      end
+
+      it do
+        expect(result.first).to eq @b
+        expect(result.second).to eq @c
+        expect(result.last).to eq @a
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi @fractaledmind - 

The purpose of this is to be able to handle sorting of Enumerable sets that contain nil values. Without this change, the sorting version of the EnumerableStrategy#execute method will raise when it attempts to multiply the derived numeric equivalent of a value by the direction_multiplier. The derived numeric equivalent of nil values in this code is nil, which can't be used in math. 

I considered solving this problem by trying to find a numeric sentinel value to use as the derived numeric equivalent of nil values, but I abandoned that approach because there is no sentinel value that will result in a correct sorting of nils when the input set is a list of arbitrarily large or small numbers. I would have to transform all inputs in the `transform_to_sortable_numeric` method to ensure they are within a certain range such that I could choose a nil sentinel value outside of that range. In the end, the approach I chose instead as seen below seems cleaner.

With this change, in an ASC sort, nils float to the end of the list. In a DESC sort, nils float to the start of the list. I chose this behavior because it is how Oracle works, although I note SQLite seems to do the opposite. I'm open to reversing which sort of sort floats nils in which direction.