### PR TITLE
WIP: Implement first pass at type-hinting

### DIFF
--- a/lib/action_set.rb
+++ b/lib/action_set.rb
@@ -71,7 +71,7 @@ module ActionSet
     end
 
     def klass_for_keypath(keypath, set)
-      if klass = set.configuration.dig('types', keypath.join('.'))
+      if klass = set&.configuration&.dig('types', keypath.join('.'))
         return klass
       end
 

--- a/lib/action_set.rb
+++ b/lib/action_set.rb
@@ -71,8 +71,9 @@ module ActionSet
     end
 
     def klass_for_keypath(keypath, set)
-      if klass = set&.configuration&.dig('types', keypath.join('.'))
-        return klass
+      if set.respond_to?(:configuration)
+        klass = set.configuration&.dig('types', keypath.join('.'))
+        return klass unless klass.nil?
       end
 
       if set.is_a?(ActiveRecord::Relation) || set.view.is_a?(ActiveRecord::Relation)

--- a/lib/action_set.rb
+++ b/lib/action_set.rb
@@ -66,7 +66,6 @@ module ActionSet
 
     def filter_typecasted_value_for(keypath, value, set)
       klass = klass_for_keypath(keypath, set)
-      Rails.logger.info "klass is #{klass}"
       ActionSet::AttributeValue.new(value)
                                .cast(to: klass)
     end

--- a/lib/active_set.rb
+++ b/lib/active_set.rb
@@ -35,12 +35,13 @@ class ActiveSet
     @configuration = Configuration.new
   end
 
-  attr_reader :set, :view, :instructions
+  attr_reader :configuration, :set, :view, :instructions
 
-  def initialize(set, view: nil, instructions: {})
+  def initialize(set, view: nil, instructions: {}, configuration: {})
     @set = set
     @view = view || set
     @instructions = instructions
+    @configuration = configuration
   end
 
   def each(&block)


### PR DESCRIPTION
This isn't pretty yet, but this works for the CAMS use cases. This allows
a configuration hash to be passed in that, for now, just includes type
information. That lets us short-circuit typecasting for filtering so that
we don't have to hit the database to find the types of computed attributes.