### PR TITLE
Fix a couple of bugs in klass_for_keypath

### DIFF
--- a/lib/action_set/filter_instructions.rb
+++ b/lib/action_set/filter_instructions.rb
@@ -54,12 +54,12 @@ module ActionSet
       if @controller.respond_to?(:filter_set_types, true)
         type_declarations = @controller.public_send(:filter_set_types)
         types = type_declarations['types'] || type_declarations[:types]
-        klass = types[keypath.join('.')]
+        klass = types.fetch(keypath.join('.'), nil)
         return klass if klass
       end
 
       if set.is_a?(ActiveRecord::Relation) || set.view.is_a?(ActiveRecord::Relation)
-        klass_type = set.model.columns_hash.fetch(keypath, nil)&.type
+        klass_type = set.model.columns_hash.fetch(keypath.join('.'), nil)&.type
         return klass_type.class if klass_type
       end
 


### PR DESCRIPTION
This fixes a couple of bugs I hit in the new type-hinting code:

1. If `filter_set_types` is defined by the controller, but the hash it returns doesn't include the keypath, make sure the hash lookup doesn't throw an exception.

2. When inspecting the ActiveRecord columns_hash, make sure an array keypath is converted to a string.